### PR TITLE
fixed timeline is shown after half hour of now

### DIFF
--- a/DDCalendarView_objc/DDCalendarSingleDayView.m
+++ b/DDCalendarView_objc/DDCalendarSingleDayView.m
@@ -252,7 +252,6 @@
         NSInteger days = [self.date daysFromDate:[NSDate date]];
         NSDate *date = [NSDate dateWithHour:now.hour min:now.minute inDays:days];
         CGPoint datePoint = [self pointForDate:date];
-        datePoint.y += HEIGHT_CELL_MIN/2;
         datePoint.y += 2; //;)
         
         CGRect f = self.bounds;


### PR DESCRIPTION
As I have seen, a timeline is not shown correctly.
If now is 0:15, a timeline is shown on 0:45.
So I removed a height adjustment value.